### PR TITLE
fix ol containing invalid child node types

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,21 @@
 	<h2>Main Characters</h2>
 		<p>There are three main characters:</p>
 			<ol>
-				<li>Harry Potter</li>
+				<li>
+					Harry Potter<br>
 					<img src="https://upload.wikimedia.org/wikipedia/en/4/44/HarryPotter5poster.jpg">
-				<li>Hermione Granger</li>
+				</li>
+					
+				<li>
+					Hermione Granger<br>
 					<img src="https://pbs.twimg.com/profile_images/527201530102161408/M_Uv2Xjr.jpeg">
-				<li>Ron Weasley</li>
+				</li>
+					
+				<li>
+					Ron Weasley<br>
 					<img src="https://upload.wikimedia.org/wikipedia/en/5/5e/Ron_Weasley_poster.jpg">
+				</li>
+					
 			</ol>
 	<br>
 	<h2>Table Reference of Main Characters</h2>


### PR DESCRIPTION
img isn't a valid child of a ol node. Since the intent seem to be having the images be associated with the name, grouping them makes sense.
